### PR TITLE
Add BE Python Lint and Format check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,14 @@ jobs:
         run: |
           docker build -t web-bff-dev-img -f ./web-bff/Dockerfile.dev ./web-bff
 
+      - name: Lint and format
+        run: |
+          docker run -p 8000:8000 --name web-bff-lint-container \
+            -v ./web-bff/tests:/src/tests \
+            --rm \
+            web-bff-dev-img \
+            ci-check
+
       - name: Create current timestamp environment variable
         run: echo "TIMESTAMP=$(date +%Y%m%d-%H%M%S)" >> $GITHUB_ENV
 

--- a/scripts/run-make.sh
+++ b/scripts/run-make.sh
@@ -2,7 +2,7 @@
 echo "Building Web bff Docker image for development..."
 docker build --progress=plain -t web-bff-dev -f ./web-bff/Dockerfile.dev ./web-bff
 
-echo "Running Web bff Docker container for test and coverage reports..."
+echo "Running Web BFF cocker image for development..."
 docker run -p 8000:8000 --name web-bff-dev-container \
 	-v $(PWD)/web-bff/app:/src/app \
 	-v $(PWD)/web-bff/tests:/src/tests \

--- a/scripts/run-make.sh
+++ b/scripts/run-make.sh
@@ -2,7 +2,7 @@
 echo "Building Web bff Docker image for development..."
 docker build --progress=plain -t web-bff-dev -f ./web-bff/Dockerfile.dev ./web-bff
 
-echo "Running Web BFF cocker image for development..."
+echo "Running Web BFF docker image for development..."
 docker run -p 8000:8000 --name web-bff-dev-container \
 	-v $(PWD)/web-bff/app:/src/app \
 	-v $(PWD)/web-bff/tests:/src/tests \

--- a/web-bff/Makefile
+++ b/web-bff/Makefile
@@ -31,6 +31,19 @@ poetry-add:
 	@poetry add $(package)
 	@poetry lock
 
+# In local dev environment fix lint/format issues if found
+check:
+	@echo "Linting..."
+	@poetry run ruff check --fix .
+	@echo "Linting done.\nNow formatting..."
+	@poetry run ruff format .
+
+# In CI run DO NOT fix lint/format issues instead just report them
+ci-check:
+	@echo "Linting..."
+	@poetry run ruff check .
+	@echo "Linting done.\nNow formatting..."
+	@poetry run ruff format --check .
 
 # pre-commit:
 # 	@echo "Running pre-commit tasks (lint fix and format)..."

--- a/web-bff/app/main.py
+++ b/web-bff/app/main.py
@@ -1,5 +1,3 @@
-import logging
-
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 

--- a/web-bff/app/presentation/health_routes.py
+++ b/web-bff/app/presentation/health_routes.py
@@ -1,9 +1,7 @@
 from fastapi import APIRouter
 
-from app.application.device_service import DeviceService
-from app.domain.models.device_model import DeviceDTO
-
 health_router = APIRouter()
+
 
 @health_router.get("/health", response_model=dict)
 async def health_check():

--- a/web-bff/pyproject.toml
+++ b/web-bff/pyproject.toml
@@ -40,9 +40,6 @@ virtualenv = "==20.29.3"
 # Use Black-compatible line length
 line-length = 88
 
-# Enable automatic fixing of issues
-fix = true
-
 # Files and directories to exclude from linting
 exclude = [
   ".git",
@@ -53,6 +50,7 @@ exclude = [
   "tests",
 ]
 
+[tool.lint]
 # Enable essential linting rules
 select = [
   "E", # Pycodestyle (Error)
@@ -73,23 +71,20 @@ ignore = [
   "C901", # Ignore function complexity (adjust if needed)
 ]
 
-# Set the target Python version
-target-version = "py310" # Adjust according to your FastAPI project
-
-[tool.ruff.isort]
+[tool.lint.isort]
 # Ensure imports are grouped logically
 known-first-party = ["app"]
 section-order = ["future", "standard-library", "third-party", "first-party", "local-folder"]
 
-[tool.ruff.flake8-quotes]
+[tool.lint.flake8-quotes]
 # Ensure consistent use of double quotes
 inline-quotes = "double"
 
-[tool.ruff.mccabe]
+[tool.lint.mccabe]
 # Set the maximum allowed complexity for functions
 max-complexity = 10
 
-[tool.ruff.pyupgrade]
+[tool.lint.pyupgrade]
 # Upgrade syntax for newer Python versions
 keep-runtime-typing = true
 


### PR DESCRIPTION
### Changes
- Add BE Python Lint and Format check for below environments,
  - Local development environment
    - Command to run: `./scripts/run-make.sh check`
    - In local development environment, lint and format errors are fixed automatically when issuing the above command
  - CI environment
    - In CI environment lint and format errors are just reported and not fixed

### Trello Card
- https://trello.com/c/uB6hhLYK